### PR TITLE
Generate Documents from Quote

### DIFF
--- a/force-app/main/default/classes/controllers/PandaDocQuoteController.cls
+++ b/force-app/main/default/classes/controllers/PandaDocQuoteController.cls
@@ -94,6 +94,12 @@ public class PandaDocQuoteController {
       if(quoteType.equalsIgnoreCase('Callsheet')){
           return PandadocCallSheetController.createPandaDocCallSheet(opportunityId);
       }
+      if(!((String)opportunityId).startsWith('006')){
+          Opportunity oppFromQuote = new OpportunitySelector()
+          .selectOpportunitiesByQuoteIds(new Set<Id>{ opportunityId })
+          .get(0);
+          opportunityId = oppFromQuote.Id;
+      }
     PandaDocQuoteController controller = new PandaDocQuoteController(
       opportunityId,
       quoteType.toLowerCase()
@@ -149,9 +155,17 @@ public class PandaDocQuoteController {
     String opportunityId
   ) {
     try {
-      Opportunity opp = new OpportunitySelector()
-        .selectOpportunitiesByIds(new Set<Id>{ opportunityId })
-        .get(0);
+        Opportunity opp;
+        if(((String)opportunityId).startsWith('006')){
+            opp = new OpportunitySelector()
+                .selectOpportunitiesByIds(new Set<Id>{ opportunityId })
+                .get(0);
+        }else{
+            opp = new OpportunitySelector()
+                .selectOpportunitiesByQuoteIds(new Set<Id>{ opportunityId })
+                .get(0);
+        }
+        
       return PandadocApi.checkDocumentStatus(
         statusUrl,
         opp.Division__r.Name.toLowerCase()
@@ -171,9 +185,17 @@ public class PandaDocQuoteController {
     try {
       // Fetch the document content from PandaDoc API
 
-      Opportunity opp = new OpportunitySelector()
-        .selectOpportunitiesByIds(new Set<Id>{ opportunityId })
-        .get(0);
+        Opportunity opp;
+        if(((String)opportunityId).startsWith('006')){
+            opp = new OpportunitySelector()
+                .selectOpportunitiesByIds(new Set<Id>{ opportunityId })
+                .get(0);
+        }else{
+            opp = new OpportunitySelector()
+                .selectOpportunitiesByQuoteIds(new Set<Id>{ opportunityId })
+                .get(0);
+            opportunityId = opp.Id;
+        }
       Blob documentContent = PandadocApi.getDocumentContent(
         documentId,
         opp.Division__r.Name.toLowerCase()

--- a/force-app/main/default/classes/selectors/OpportunitySelector.cls
+++ b/force-app/main/default/classes/selectors/OpportunitySelector.cls
@@ -29,7 +29,7 @@ public with sharing class OpportunitySelector {
               Invoice_Amount__c,
               Invoice_Due_Date__c,
               Payment_Terms__c,
-              CreatedDate, (SELECT Id FROM SBQQ__Quotes2__r WHERE SBQQ__Primary__c = true)
+              CreatedDate, (SELECT Id FROM SBQQ__Quotes2__r WHERE SBQQ__Primary__c = true),
               Lead_Producer__c,
               Lead_Producer_Email__c,
         			Division__r.Division_Leader__r.Phone
@@ -37,4 +37,38 @@ public with sharing class OpportunitySelector {
             WHERE Id IN :ids
         ];
     }
+    public List<Opportunity> selectOpportunitiesByQuoteIds(Set<Id> ids) {
+        return [
+            SELECT
+              Id,
+            Name,
+              CC_Payment__c,
+              Lead_Type__c,
+              Division__r.Name,
+              Account.Name,
+              Opportunity_Descriptor__c,
+              InvoiceNumber__c,
+              Payment__c,
+              Tax_to_collect__c,
+              Shoot_Date__c,
+              CC_Fee_invoice__c,
+              Required_Deposit__c,
+              PrimaryContact__r.Email,
+              PrimaryContact__r.FirstName,
+              PrimaryContact__r.LastName,
+              Stage_Document_Automated__c,
+              Additional_Client_CC__c,
+              Amount_QB__c,
+              Invoice_Amount__c,
+              Invoice_Due_Date__c,
+              Payment_Terms__c,
+              CreatedDate,
+              Lead_Producer__c,
+              Lead_Producer_Email__c,
+        			Division__r.Division_Leader__r.Phone
+            FROM Opportunity
+            WHERE Id IN (SELECT SBQQ__Opportunity2__c from SBQQ__Quote__c WHERE Id IN :ids)
+        ];
+    }
+    
 }

--- a/force-app/main/default/classes/tests/pandadoc/PandaDocQuoteControllerTest.cls
+++ b/force-app/main/default/classes/tests/pandadoc/PandaDocQuoteControllerTest.cls
@@ -56,6 +56,44 @@ private class PandaDocQuoteControllerTest {
         );
       }
       insert opportunities;
+      //insert quote
+      SBQQ__Quote__c quote = new SBQQ__Quote__c(
+          SBQQ__Opportunity2__c = opportunities[0].Id,
+          SBQQ__Primary__c = TRUE
+      );
+      insert quote;
+      Id pricebookId = Test.getStandardPricebookId();
+      Pricebook2 standardPricebook = new Pricebook2(
+          Id = pricebookId,
+          IsActive = true
+      );
+      update standardPricebook;
+      // Create Product
+      Product2 product = new Product2(
+          Name = 'Test Product',
+          IsActive = TRUE
+      );
+      insert product;
+      
+      PricebookEntry standardPriceEntry = new PricebookEntry(
+          Pricebook2Id = standardPricebook.Id,
+          Product2Id = product.Id,
+          UnitPrice = 100,
+          IsActive = true
+      );
+      insert standardPriceEntry;
+      
+      // Create Quote Line Item
+      SBQQ__QuoteLine__c qli = new SBQQ__QuoteLine__c(
+          SBQQ__Quote__c = quote.Id,
+          SBQQ__Product__c = product.Id,
+          SBQQ__ListPrice__c = 100,
+          SBQQ__Quantity__c = 1,
+          SBQQ__SubscriptionTerm__c = 12,
+          Vendor__c = contacts[0].Id,
+          Client_Info__c = 'Test Client Info'
+      );
+        insert qli;
     }
   }
 
@@ -396,5 +434,22 @@ private class PandaDocQuoteControllerTest {
     }
 
     System.assertEquals(2, ccRecipientCount, 'There should be 2 CC recipients');
+  }
+    @isTest
+  static void testCreatePandaDocQuote_WithQuoteRecord() {
+      SBQQ__Quote__c quote = [SELECT Id FROM SBQQ__Quote__c LIMIT 1];
+      PandaDocApiMock mock = PandaDocApiMock.createSuccessMock();
+      Test.setMock(HttpCalloutMock.class, mock);
+      
+      // WHEN
+      Test.startTest();
+      Map<String, String> result = PandaDocQuoteController.createPandaDocQuote(
+          quote.Id,
+          'estimate'
+      );
+      Test.stopTest();
+      
+      // THEN
+      System.assertNotEquals(null, result, 'Result should not be null');
   }
 }


### PR DESCRIPTION
Contains code changes for following ticket : 
https://app.asana.com/0/1208713456754497/1208514801643566
PD steps : 
Create quick actions on Quote as same as Opportunity named 'Generate Proposal', 'Generate Invoice', 'Generate Estimate', and put them on flexi page with visibility condition as "Primary" = TRUE.